### PR TITLE
Handle errors correctly in request callback

### DIFF
--- a/lib/yub.js
+++ b/lib/yub.js
@@ -95,8 +95,10 @@ var verify = function (otp, callback) {
 
     // to https request
     request({ uri: uri, qs: params}, function (err, res, body) {
-      
       // error
+      if (err) {
+        return callback(err, null);
+      }
       if (res.statusCode !== 200) {
         return callback(true, null);
       }


### PR DESCRIPTION
The library was failing when trying to use it with a library like Nock which intercepts HTTP requests.