### PR TITLE
Don't lock request dependency to an exact version

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,6 @@
   "author": "Glynn Bird",
   "license": "Apache-2.0",
   "dependencies": {
-    "request": "2.60.0"
+    "request": "^2.60.0"
   }
 }


### PR DESCRIPTION
Locking directly to `2.60.0` prevents minor updates and npm deduping.