### PR TITLE
Fix HMAC calculation; fixes use on Node6

### DIFF
--- a/lib/yub.js
+++ b/lib/yub.js
@@ -40,14 +40,14 @@ var calculateIdentity = function (otp) {
 };
 
 // extract the encrypted portion of the Yubikey OTP i.e.
-//  the last 32 characters 
+//  the last 32 characters
 var calculateEncrypted = function (otp) {
   var len = otp.length;
   return (len > 32) ? otp.substring(len - 32, len) : null;
 };
 
 // calculate the string that is required to be hashed i.e.
-//  keys in alphabetical order, separated from values by '='  
+//  keys in alphabetical order, separated from values by '='
 //  and by each other by '&' (like querystrings, but without the escaping)
 var calculateStringToHash = function (obj) {
   return Object
@@ -63,7 +63,7 @@ var calculateStringToHash = function (obj) {
 // according to instructions here: https://code.google.com/p/yubikey-val-server-php/wiki/ValidationProtocolV20
 var calculateHmac = function (obj) {
   var str = calculateStringToHash(obj);
-  var buf = new Buffer(secretKey, 'base64').toString('binary');
+  var buf = new Buffer(secretKey, 'base64');
   var hmac = crypto.createHmac('sha1', buf);
   return hmac.update(str).digest('base64');
 };
@@ -72,23 +72,23 @@ var calculateHmac = function (obj) {
 // calls back with (err,data). If err is not null, then you have
 // an object in data to work with
 var verify = function (otp, callback) {
-  
+
   // create 40 character random string
   crypto.randomBytes(nonceLength, function (err, buf) {
-    
+
     // turn it to hex
     var nonce = buf.toString('hex').slice(0, 40);
-    
+
     // create parameters to send to web service
     var params = {
       id: clientID,
       nonce: nonce,
       otp: otp
     };
-    
+
     // calculate sha1 signature
-//    params.h = calculateHmac(params);
-    
+    params.h = calculateHmac(params);
+
     // calculate url
     var server = servers[Math.floor(Math.random() * servers.length)];
     var uri = 'https://' + server + '/wsapi/2.0/verify';
@@ -102,19 +102,19 @@ var verify = function (otp, callback) {
       if (res.statusCode !== 200) {
         return callback(true, null);
       }
-      
+
       // parse the return value
       body = parse(body);
 
-      // check whether the signature of the reply 
+      // check whether the signature of the reply
        var bodyh = body.h;
       delete body.h;
       var h = calculateHmac(body);
       body.signatureVerified = (bodyh === h.replace("=", ''));
-      
+
       // check whether the nonce is the same as the one we gave it
       body.nonceVerified = (nonce === body.nonce);
-      
+
       // calculate the key's identity
       body.identity = null;
       body.encrypted = null;
@@ -129,7 +129,7 @@ var verify = function (otp, callback) {
       } else {
         body.valid = false;
       }
-      
+
       callback(null, body);
 
     });
@@ -139,10 +139,10 @@ var verify = function (otp, callback) {
 // if we have no network connectivity, we still may wish to extract the
 // identity from the OTP, but handy for offline applications
 var verifyOffline = function (otp, callback) {
-      
+
   var identity = calculateIdentity(otp);
   var encrypted = calculateEncrypted(otp);
-  
+
   var body = {
       t: null,
       otp: otp,
@@ -156,8 +156,8 @@ var verifyOffline = function (otp, callback) {
       encryptedHex: modhex.decode(encrypted),
       serial: modhex.decodeInt(identity),
       valid: false
-  };    
-      
+  };
+
   callback(null,  body);
 };
 


### PR DESCRIPTION
Key change is L66 - converting a Buffer to a binary string then instantiating a new Buffer from it is not necessary and potentially lossy if Node chooses to interpret it as `'utf8'`, which it does by default.

It appears no change was made in Yubico's API, we're just seeing Node6 buffer changes break this.